### PR TITLE
Fix mask for payload byte

### DIFF
--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -249,7 +249,8 @@ function Websocket:process_frame(data)
 
   --- @type boolean | number
   local mask = bit.band(data:byte(index), 0x80) == 0x80
-  local payload_length = bit.band(data:byte(index), 0xEF)
+
+  local payload_length = bit.band(data:byte(index), 0x7F)
 
   index = index + 1 --index 3
   if payload_length == 126 then


### PR DESCRIPTION
This should be masking the highest bit but 0xEF mask is "1110 1111", changed the mask to 0x7F to mask "0111 1111"