### PR TITLE
Handle partial data in the buffer

### DIFF
--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -95,12 +95,13 @@ function Websocket:connect()
 
   -- create a TCP client and connect to the host
   local client = uv.new_tcp()
-  client:recv_buffer_size(1048575)
 
   if not client then
     print("Error creating TCP client for websocket")
     return
   end
+
+  uv.recv_buffer_size(client, 1048575)
 
   client:connect(addr, self.port, function(error)
     if error then

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -254,6 +254,7 @@ function Websocket:process_frame(data)
       self.current_frame = {
           data='',
           opcode=0,
+          payload_length=0,
           continue=true
       }
   end
@@ -302,7 +303,7 @@ function Websocket:process_frame(data)
         index = index + 4
       end
       self.current_frame.mask = mask
-      self.current_frame.payload_length = payload_length
+      self.current_frame.payload_length = self.current_frame.payload_length + payload_length
       self.current_frame.continue = false
   end
 

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -137,6 +137,7 @@ function Websocket:connect()
             return
           end
 
+          print('received', #received_data, 'bytes')
           -- The size of the internal buffer for receiving data is limited
           -- If the data is larger than that, then it will be received in
           -- multiple chunks.

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -340,12 +340,12 @@ function Websocket:process_frame(data)
     self.previous = ""
     self.current_frame = nil
 
-    if frame:to_string() ~= data_old then
-      print("Error: frame does not match data")
-      print_bases.print_hex(data_old)
-      print_bases.print_hex(frame:to_string())
-      return false
-    end
+    --if frame:to_string() ~= data_old then
+      --print("Error: frame does not match data")
+      --print_bases.print_hex(data_old)
+      --print_bases.print_hex(frame:to_string())
+      --return false
+    --end
 
     if frame.opcode == Opcode.CLOSE then
       self:close()

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -308,10 +308,10 @@ function Websocket:process_frame(data)
   if data:len() ~= payload_length then
     print("Error: payload length does not match data length")
     print(data:len() .. " ~= " .. payload_length)
-    print_bases.print_hex(string.sub(data_old, 1, 10))
     --print(data_old)
     return false
   end
+  print_bases.print_hex(string.sub(data_old, 1, 10))
 
   if fin then
     local frame = WebsocketFrame:new({

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -249,7 +249,7 @@ function Websocket:process_frame(data)
 
   --- @type boolean | number
   local mask = bit.band(data:byte(index), 0x80) == 0x80
-  local payload_length = bit.band(data:byte(index), 0xEF)
+  local payload_length = bit.band(data:byte(index), 0x7E)
 
   index = index + 1 --index 3
   if payload_length == 126 then

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -143,6 +143,9 @@ function Websocket:connect()
           -- multiple chunks.
           -- Here we join them. Not sure this is the best way of doing this,
           -- just testing for now.
+          if #prefix > 0 then
+              received_data = string.sub(received_data, 3, -1)
+          end
           local data = prefix .. received_data
           -- Assuming the size is int16_max+1, because that's true on my system.
           -- Will look into a way of querying this from libuv.

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -287,6 +287,8 @@ function Websocket:process_frame(data)
         index = index + 8
       end
 
+      print_bases.print_hex(string.sub(data, 1, index+4))
+      print('fin:', self.current_frame.fin, 'opcode:', self.current_frame.opcode, 'payload_length:', payload_length)
       if mask then
         mask = bit.bor(
           bit.lshift(data:byte(index), 24),
@@ -296,8 +298,6 @@ function Websocket:process_frame(data)
         )
         index = index + 4
       end
-      print('fin:', self.current_frame.fin, 'opcode:', self.current_frame.opcode, 'payload_length:', payload_length)
-      print_bases.print_hex(string.sub(data, 1, index-1))
       self.current_frame.mask = mask
       self.current_frame.payload_length = payload_length
   end

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -159,8 +159,9 @@ function Websocket:connect()
                 frame, data = self:process_frame(data)
 
                 if frame then
-                  print('We have a complete frame! bytes:', #frame.payload)
+                  print('We have a complete frame! bytes:', #frame.payload, 'opcode:', frame.opcode)
                   for _, fn in ipairs(self.on_message) do
+                    print('Running frame callback...')
                     fn(frame)
                   end
                 end

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -150,7 +150,7 @@ function Websocket:connect()
           -- Assuming the size is int16_max+1, because that's true on my system.
           -- Will look into a way of querying this from libuv.
           if #received_data == 0x10000 then
-              prefix = string.sub(data, 3, -1)
+              prefix = data
               return
           else
               prefix = ''

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -285,7 +285,7 @@ function Websocket:process_frame(data)
   if data:len() ~= payload_length then
     print("Error: payload length does not match data length")
     print(data:len() .. " ~= " .. payload_length)
-    print(print_bases.print_hex(data.sub(1, 10)))
+    print(print_bases.print_hex(string.sub(data, 1, 10)))
     --print(data_old)
     return false
   end

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -138,13 +138,13 @@ function Websocket:connect()
           end
 
           print('received', #received_data, 'bytes')
-          -- The size of the internal buffer for receiving data is limited
+          -- The size of the internal buffer for receiving data is limited.
           -- If the data is larger than that, then it will be received in
           -- multiple chunks.
           -- Here we join them. Not sure this is the best way of doing this,
           -- just testing for now.
           if #prefix > 0 then
-              received_data = string.sub(received_data, 3, -1)
+              received_data = received_data:sub(3)
           end
           local data = prefix .. received_data
           -- Assuming the size is int16_max+1, because that's true on my system.
@@ -155,7 +155,6 @@ function Websocket:connect()
           else
               prefix = ''
           end
-          print('processing', #data, 'bytes')
 
           -- TODO: parse and return readers
           if data and self.frame_count == 0 then
@@ -172,6 +171,7 @@ function Websocket:connect()
           end
 
           if data and self.frame_count > 0 then
+            print('processing', #data, 'bytes')
             local frame = self:process_frame(data)
 
             if frame then

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -285,7 +285,7 @@ function Websocket:process_frame(data)
   if data:len() ~= payload_length then
     print("Error: payload length does not match data length")
     print(data:len() .. " ~= " .. payload_length)
-    print_bases.print_hex(data.sub(1, 10))
+    print(print_bases.print_hex(data.sub(1, 10)))
     --print(data_old)
     return false
   end

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -159,6 +159,7 @@ function Websocket:connect()
                 frame, data = self:process_frame(data)
 
                 if frame then
+                  print('We have a complete frame! bytes:', #frame.payload)
                   for _, fn in ipairs(self.on_message) do
                     fn(frame)
                   end

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -285,7 +285,7 @@ function Websocket:process_frame(data)
   if data:len() ~= payload_length then
     print("Error: payload length does not match data length")
     print(data:len() .. " ~= " .. payload_length)
-    print_bases.print_hex(string.sub(data, 1, 10))
+    print_bases.print_hex(string.sub(data_old, 1, 10))
     --print(data_old)
     return false
   end

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -285,7 +285,7 @@ function Websocket:process_frame(data)
   if data:len() ~= payload_length then
     print("Error: payload length does not match data length")
     print(data:len() .. " ~= " .. payload_length)
-    print_bases.print_hex(data.sub(0
+    print_bases.print_hex(data.sub(1, 10))
     --print(data_old)
     return false
   end

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -253,7 +253,7 @@ function Websocket:process_frame(data)
   if self.current_frame == nil then
       self.current_frame = {
           data='',
-          opcode=0
+          opcode=0,
           continue=true
       }
   end

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -147,7 +147,7 @@ function Websocket:connect()
           -- Assuming the size is int16_max+1, because that's true on my system.
           -- Will look into a way of querying this from libuv.
           if #received_data == 0x10000 then
-              prefix = data
+              prefix = string.sub(data, 3, -1)
               return
           else
               prefix = ''

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -143,7 +143,7 @@ function Websocket:connect()
             local response = data:match("HTTP/1.1 (%d+)")
 
             if not response or response ~= "101" then
-              print("Error: websocket handshake failed")
+              print("Error: websocket handshake failed:", response)
               return
             end
             self.client = client

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -317,7 +317,7 @@ function Websocket:process_frame(data)
   end
   local left = nil
   if data_size > payload_length then
-      left = self.current_frame.data:sub(payload_length, -1)
+      left = self.current_frame.data:sub(payload_length+1, -1)
       self.current_frame.data = self.current_frame.data:sub(1, payload_length)
   end
   -- done fetching the data, make sure to parse next frame header

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -249,7 +249,7 @@ function Websocket:process_frame(data)
 
   --- @type boolean | number
   local mask = bit.band(data:byte(index), 0x80) == 0x80
-  local payload_length = bit.band(data:byte(index), 0x7E)
+  local payload_length = bit.band(data:byte(index), 0x7F)
 
   index = index + 1 --index 3
   if payload_length == 126 then
@@ -285,7 +285,8 @@ function Websocket:process_frame(data)
   if data:len() ~= payload_length then
     print("Error: payload length does not match data length")
     print(data:len() .. " ~= " .. payload_length)
-    print(data_old)
+    print_bases.print_hex(data.sub(0
+    --print(data_old)
     return false
   end
 

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -94,8 +94,8 @@ function Websocket:connect()
   local addr = addrinfo[1].addr
 
   -- create a TCP client and connect to the host
-  uv:recv_buffer_size(1048575)
   local client = uv.new_tcp()
+  client:recv_buffer_size(1048575)
 
   if not client then
     print("Error creating TCP client for websocket")

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -94,6 +94,7 @@ function Websocket:connect()
   local addr = addrinfo[1].addr
 
   -- create a TCP client and connect to the host
+  uv:recv_buffer_size(1048575)
   local client = uv.new_tcp()
 
   if not client then

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -368,7 +368,7 @@ function Websocket:process_frame(data)
   if self.current_frame.opcode == Opcode.CONTINUATION or self.current_frame.opcode == Opcode.TEXT then
     self.previous = self.previous .. data
   end
-  return false
+  return false, left
 end
 
 function Websocket:send_frame(frame)

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -308,13 +308,14 @@ function Websocket:process_frame(data)
   local data_old = "" .. data
   data = data:sub(index)
 
+  print('fin:', fin, 'opcode:', opcode, 'payload_length:', payload_length)
+  print_bases.print_hex(string.sub(data_old, 1, 10))
   if data:len() ~= payload_length then
     print("Error: payload length does not match data length")
     print(data:len() .. " ~= " .. payload_length)
     --print(data_old)
     return false
   end
-  print_bases.print_hex(string.sub(data_old, 1, 10))
 
   if fin then
     local frame = WebsocketFrame:new({

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -145,9 +145,9 @@ function Websocket:connect()
           -- just testing for now.
           if #prefix > 0 then
               print('ignoring 2 bytes:')
-              print_bases.print_hex(received_data:sub(1, 2))
+              print_bases.print_hex(received_data:sub(-3, -1))
 
-              received_data = received_data:sub(3)
+              received_data = received_data:sub(1, -3)
           end
           local data = prefix .. received_data
           -- Assuming the size is int16_max+1, because that's true on my system.

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -285,7 +285,7 @@ function Websocket:process_frame(data)
   if data:len() ~= payload_length then
     print("Error: payload length does not match data length")
     print(data:len() .. " ~= " .. payload_length)
-    print(print_bases.print_hex(string.sub(data, 1, 10)))
+    print_bases.print_hex(string.sub(data, 1, 10))
     --print(data_old)
     return false
   end

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -144,6 +144,9 @@ function Websocket:connect()
           -- Here we join them. Not sure this is the best way of doing this,
           -- just testing for now.
           if #prefix > 0 then
+              print('ignoring 2 bytes:')
+              print_bases.print_hex(received_data:sub(1, 2))
+
               received_data = received_data:sub(3)
           end
           local data = prefix .. received_data

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -250,14 +250,17 @@ end
 ---@return false | WebsocketFrame, string|nil # false if not finished, frame is finished
 function Websocket:process_frame(data)
   local index = 1
-  if self.current_frame == nil or self.current_frame.continue then
-      print('processing header...')
+  if self.current_frame == nil then
       self.current_frame = {
           data='',
           opcode=0
+          continue=true
       }
+  end
+  if self.current_frame.continue then
+      print('processing header...')
       self.current_frame.fin = bit.band(data:byte(index), 0x80) == 0x80
-      opcode = bit.band(data:byte(index), 0x0F)
+      local opcode = bit.band(data:byte(index), 0x0F)
 
       -- continuation frames have opcode, so in those cases
       -- we just keep the original opcode
@@ -300,11 +303,11 @@ function Websocket:process_frame(data)
       end
       self.current_frame.mask = mask
       self.current_frame.payload_length = payload_length
+      self.current_frame.continue = false
   end
 
   local data_old = "" .. data
   self.current_frame.data = self.current_frame.data .. data:sub(index)
-  print('current frame has', #self.current_frame.data, 'bytes')
 
   local data_size = self.current_frame.data:len()
   local payload_length = self.current_frame.payload_length
@@ -320,6 +323,8 @@ function Websocket:process_frame(data)
       left = self.current_frame.data:sub(payload_length+1, -1)
       self.current_frame.data = self.current_frame.data:sub(1, payload_length)
   end
+
+  print('current frame has', #self.current_frame.data, 'bytes (wants', self.current_frame.payload_length, ')')
   -- done fetching the data, make sure to parse next frame header
   -- in case it's a continuation frame
   self.current_frame.continue = true

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -144,14 +144,15 @@ function Websocket:connect()
           -- Here we join them. Not sure this is the best way of doing this,
           -- just testing for now.
           local data = prefix .. received_data
-          -- Assuming the size is int16_max, because that's true on my system.
+          -- Assuming the size is int16_max+1, because that's true on my system.
           -- Will look into a way of querying this from libuv.
-          if #received_data == 0xFFFF then
+          if #received_data == 0x10000 then
               prefix = data
               return
           else
               prefix = ''
           end
+          print('processing', #data, 'bytes')
 
           -- TODO: parse and return readers
           if data and self.frame_count == 0 then

--- a/lua/websocket.lua
+++ b/lua/websocket.lua
@@ -101,8 +101,6 @@ function Websocket:connect()
     return
   end
 
-  uv.recv_buffer_size(client, 1048575)
-
   client:connect(addr, self.port, function(error)
     if error then
       print("Error connecting to websocket: " .. error)


### PR DESCRIPTION
When fetching data from the TCP socket, the internal buffer has a limited size.

This means that when processing larger frames (on my setup, larger than 2¹⁶ bytes) there is a chance that the buffer only has partial data for that frame. This PR changes the processing to make sure more data is processed in the same frame whenever necessary.

There is also the possibility that multiple websocket frames are embedded into a single data buffer. Namely, some websocket libraries (looking at you, [Gorilla](https://gorilla.github.io/)!) like to have text frames always be fragmented, and send an empty continuation frame to mark the end of the message. This continuation frame is only two bytes long (0x8000) and tends to be in the same buffer as the previous frame when reading from the TCP socket. This PR handles this scenario as well.

This implementation is by no means perfect: There is a chance that the frame metadata itself might be incomplete - this PR does NOT handle this scenario. (And I'm honestly not sure if it can really happen)

As a bonus, the handling of partial data made it easier to handle continuation frames as well (Opcode = 0).